### PR TITLE
OFF-552 Change ImpId in the response to be the same as Imp.ID in the request

### DIFF
--- a/adapters/flipp/flipp.go
+++ b/adapters/flipp/flipp.go
@@ -188,7 +188,7 @@ func (a *adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 	bidResponse.Currency = DefaultCurrency
 	for _, decision := range campaignResponseBody.Decisions.Inline {
 		b := &adapters.TypedBid{
-			Bid:     buildBid(decision),
+			Bid:     buildBid(decision, request.Imp[0].ID),
 			BidType: openrtb_ext.BidType(BannerType),
 		}
 		bidResponse.Bids = append(bidResponse.Bids, b)
@@ -203,13 +203,13 @@ func getAdTypes(creativeType string) []int64 {
 	return AdTypes
 }
 
-func buildBid(decision *InlineModel) *openrtb2.Bid {
+func buildBid(decision *InlineModel, impId string) *openrtb2.Bid {
 	bid := &openrtb2.Bid{
 		CrID:  fmt.Sprint(decision.CreativeID),
 		Price: *decision.Prebid.Cpm,
 		AdM:   *decision.Prebid.Creative,
 		ID:    fmt.Sprint(decision.AdID),
-		ImpID: fmt.Sprint(decision.AdvertiserID),
+		ImpID: impId,
 	}
 	if len(decision.Contents) > 0 || decision.Contents[0] != nil || decision.Contents[0].Data != nil {
 		if decision.Contents[0].Data.Width != 0 {


### PR DESCRIPTION
Client side prebid returns an error `ERROR: ORTB response seatbid[].bid[].impid does not match any imp in request; ignoring bid {i`
Looks like ImpId has to match the one in the request for the prebidServer client adapter to return a request
After doing this, the test page on my branch (https://github.com/wishabi/shopper-ad-web/pull/341) works
(https://shopper.flipp.com/static/test/23141130d163450f4d1061e1da63617d05a2caf9/prebid-examples/server-client-prebid.html?flipp-content-code=mlei)