### PR TITLE
NF-464: Use customData maxWidth/maxHeight for bid dimensions

### DIFF
--- a/adapters/flipp/flipp.go
+++ b/adapters/flipp/flipp.go
@@ -239,7 +239,7 @@ func buildBid(decision *InlineModel, impId string, flippExtParams openrtb_ext.Im
 		ID:    fmt.Sprint(decision.AdID),
 		ImpID: impId,
 	}
-	if len(decision.Contents) > 0 || decision.Contents[0] != nil || decision.Contents[0].Data != nil {
+	if len(decision.Contents) > 0 && decision.Contents[0] != nil && decision.Contents[0].Data != nil {
 		if decision.Contents[0].Data.Width != 0 {
 			bid.W = decision.Contents[0].Data.Width
 		}
@@ -261,6 +261,14 @@ func buildBid(decision *InlineModel, impId string, flippExtParams openrtb_ext.Im
 					if floatVal, ok := value.(float64); ok {
 						bid.H = int64(floatVal)
 					}
+				}
+
+				// Prefer exact dimensions when provided
+				if v, ok := customDataMap["maxWidth"].(float64); ok && v != 0 {
+					bid.W = int64(v)
+				}
+				if v, ok := customDataMap["maxHeight"].(float64); ok && v != 0 {
+					bid.H = int64(v)
 				}
 			}
 		}

--- a/adapters/flipp/flipptest/exemplary/simple-banner-native-rich-media.json
+++ b/adapters/flipp/flipptest/exemplary/simple-banner-native-rich-media.json
@@ -1,0 +1,155 @@
+{
+    "mockBidRequest": {
+        "id": "test-request-id",
+        "test": 1,
+        "device": {
+            "ip": "123.123.123.123"
+        },
+        "site": {
+            "id": "1243066",
+            "page": "http://www.example.com/test?flipp-content-code=publisher-test"
+        },
+        "user": {
+            "id": "1234"
+        },
+        "imp": [
+            {
+                "id": "test-imp-id",
+                "tagid": "test",
+                "banner": {
+                    "format": [
+                        {
+                            "w": 300,
+                            "h": 1800
+                        }
+                    ]
+                },
+                "ext": {
+                        "bidder": {
+                                "publisherNameIdentifier": "wishabi-test-publisher",
+                                "creativeType": "NativeX",
+                                "siteId": 1243066,
+                                "zoneIds": [285431],
+                                "options": {
+                                   "startCompact": false,
+                                   "contentCode": "publisher-test-2"
+                                }
+                        }
+                }
+            }
+
+        ]
+    },
+    "httpCalls": [
+        {
+            "expectedRequest": {
+                "uri": "http://example.com/pserver",
+                "body": {
+                    "ip":"123.123.123.123",
+                    "keywords":[
+                       ""
+                    ],
+                    "placements":[
+                       {
+                          "adTypes":[
+                             4309,
+                             641
+                          ],
+                          "count":1,
+                          "divName":"inline",
+                          "prebid":{
+                             "creativeType":"NativeX",
+                             "height":1800,
+                             "publisherNameIdentifier":"wishabi-test-publisher",
+                             "requestId":"test-imp-id",
+                             "width":300
+                          },
+                          "properties":{
+                             "contentCode":"publisher-test-2"
+                          },
+                          "siteId":1243066,
+                          "zoneIds":[
+                             285431
+                          ],
+                          "options": {
+                             "contentCode": "publisher-test-2"
+                          }
+                       }
+                    ],
+                    "url":"http://www.example.com/test?flipp-content-code=publisher-test",
+                    "user":{
+                       "key":"1234"
+                    }
+                },
+                "impIDs":["test-imp-id"]
+            },
+            "mockResponse": {
+                "status": 200,
+                "body": {
+                    "decisions": {
+                        "inline": [
+                            {
+                                "adId": 183599115,
+                                "advertiserId": 1988027,
+                                "campaignId": 63285392,
+                                "contents": [
+                                    {
+                                        "data": {
+                                            "customData": {
+                                                "campaignConfigUrl": "https://campaign-config.flipp.com/dist-campaign-admin/215",
+                                                "campaignNameIdentifier": "Home Hardware",
+                                                "maxWidth": 320,
+                                                "maxHeight": 480
+                                            },
+                                            "height": 1800,
+                                            "width": 300
+                                        },
+                                        "type": "raw"
+                                    }
+                                ],
+                                "creativeId": 81325690,
+                                "flightId": 175421795,
+                                "height": 1800,
+                                "prebid": {
+                                    "cpm": 12.34,
+                                    "creative":"creativeContent",
+                                    "creativeType": "NativeX",
+                                    "requestId": "test-imp-id"
+                                },
+                                "priorityId": 232699,
+                                "width": 300
+                            }
+                        ]
+                    },
+                    "location": {
+                        "accuracy_radius": 5,
+                        "city": "Toronto",
+                        "country": "CA",
+                        "ip": "123.123.123.124",
+                        "postal_code": "M4S",
+                        "region": "ON",
+                        "region_name": "Ontario"
+                    }
+                }
+            }
+        }
+    ],
+    "expectedBidResponses": [
+        {
+            "bids": [
+                {
+                    "bid": {
+                        "id": "183599115",
+                        "impid": "test-imp-id",
+                        "price": 12.34,
+                        "adm": "creativeContent",
+                        "crid": "81325690",
+                        "w": 320,
+                        "h": 480
+                    },
+                    "type": "banner"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
Some publishers build their ad container directly from the width/height in our bid response. For Rich Media units the Flipp adapter returned the wrong dimensions (e.g. 300x250 into a 320x480 slot), cutting the unit off (reported by PMC; also caused blank space on Narcity).

This change prefers `customData.maxWidth` / `customData.maxHeight` for `bid.W` / `bid.H` when they are present and non-zero, so responsive publisher containers size correctly. Existing behavior is unchanged when those fields are absent.

Also fixes the `contents` guard in `buildBid` (`||` → `&&`) so a partial/empty response cannot panic.

## Changes
- `adapters/flipp/flipp.go`: read `maxWidth`/`maxHeight` from `contents[0].data.customData` and apply to the bid; harden the contents guard.
- `adapters/flipp/flipptest/exemplary/simple-banner-native-rich-media.json`: new fixture asserting `w=320`, `h=480` from customData.

## Testing
- `go test ./adapters/flipp/...` passes
- `gofmt` clean, `go vet` clean

## Ticket
[NF-464](https://doveconviene.atlassian.net/browse/NF-464) (under epic [NF-14](https://doveconviene.atlassian.net/browse/NF-14) Rich Media Ads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NF-464]: https://doveconviene.atlassian.net/browse/NF-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ